### PR TITLE
used !exists("mod", e, inherits=FALSE) to detect need to initialize

### DIFF
--- a/R/testMod.R
+++ b/R/testMod.R
@@ -19,7 +19,7 @@ resume.testMod <- function(e){
   # will not be fully initialized. We check for that and initialize if
   # necessary. We delegate to a method in order to ease integration of
   # additional functionality as the code base develops.
-  fromhi <- identical(e$expr, quote(hi("testMod")))
+  fromhi <- !exists("mod",e,inherits=FALSE)
   if(fromhi)initSwirl(e)
   # Execute instructions until a return to the prompt is necessary
   while(!e$prompt){


### PR DESCRIPTION
The default is inherits=TRUE which means that if "mod" does not exist in e, R looks in the enclosing environment. Thus, if you happen to have a variable named "mod" around, initialization fails.

My original fix, before actually reading the docs for exists, involved `identical(e$expr, quote(hi("testMod"))`. As was noted by a colleague, such hard-coding has disadvantages. For instance if hi is called with a vector argument:

> `hi( c("newClass", "testMod") )`,

as it might be if newClass were meant to override testMod's initSwirl and saveProgress methods, initialization would again fail.
