### PR TITLE
DON'T MERGE: Corrected order of mergeList arguments

### DIFF
--- a/R/swirl.R
+++ b/R/swirl.R
@@ -331,7 +331,7 @@ resume.default <- function(e, ...){
        !uses_func("swirlify")(e$expr)[[1]] &&
        !uses_func("nxt")(e$expr)[[1]] &&
        customTests$AUTO_DETECT_NEWVAR){
-    e$delta <- mergeLists(e$delta, safeEval(e$expr, e))
+    e$delta <- mergeLists(safeEval(e$expr, e), e$delta)
   }
   # Execute instructions until a return to the prompt is necessary
   while(!e$prompt){


### PR DESCRIPTION
Corrected order of mergeList arguments when updating delta during automatic detection of new variables.

Cleaning e$delta after failed instructions should probably be done as well, but since the above seems to correct the known problem, I've not done it. 
