### PR TITLE
Avoid double printing in safeEval()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Description: swirl turns the R console into an interactive learning
     environment. Users receive immediate feedback as they are guided through
     self-paced lessons in data science and R programming.
 URL: http://swirlstats.com
-Version: 2.2.11
+Version: 2.2.12
 License: GPL-3
 Authors@R: c(
     person("Nick", "Carchedi", email = "nick.carchedi@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# swirl 2.2.12
+
+* Use `capture.output()` to avoid double printing due to second evaluation by `safeEval()` when `AUTO_DETECT_NEWVAR` is `TRUE`.
+
 # swirl 2.2.11
 
 * Add `testit()` to functions for callback to ignore, so that swirl plays nicely with swirlify.

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -60,7 +60,9 @@ mergeLists <- function(sourceList, destList){
 safeEval <- function(expr, e){
   e1 <- cleanEnv(e$snapshot)
   ans <- list()
-  temp <- try(suppressMessages(suppressWarnings(eval(expr,e1))), silent=FALSE)
+  temp <- capture.output(
+    try(suppressMessages(suppressWarnings(eval(expr,e1))), silent=FALSE)
+    )
   if(is(temp, "try-error"))return(ans)
   for (x in ls(e1)){
     if(exists(x,globalenv()))


### PR DESCRIPTION
When `AUTO_DETECT_NEWVAR` is `TRUE`, which is the default setting, `safeEval()` causes double printing of the output from commands with side effects. Example below, before and after this pull request was implemented. 

I don't think there's any danger to using `capture.output()` where I've put it in `safeEval()`, but a reality check is usually in order.

BEFORE:

```
| In its simplest form, R can be used as an interactive calculator.
| Type 5 + 7 and press Enter.

> str(list(a=3, b=5))
List of 2
 $ a: num 3
 $ b: num 5
List of 2
 $ a: num 3
 $ b: num 5

| You're close...I can feel it! Try it again. Or, type info() for more
| options.
```

AFTER:

```
| In its simplest form, R can be used as an interactive calculator.
| Type 5 + 7 and press Enter.

> str(list(a=3, b=5))
List of 2
 $ a: num 3
 $ b: num 5

| Not quite right, but keep trying. Or, type info() for more options.
```
