### PR TITLE
DON'T MERGE: Save all user info to home directory?

### DIFF
--- a/R/menu.R
+++ b/R/menu.R
@@ -26,7 +26,7 @@ mainMenu.default <- function(e){
   # Welcome the user if necessary and set up progress tracking
   if(!exists("usr",e,inherits = FALSE)){
     e$usr <- welcome(e)
-    udat <- file.path(find.package("swirl"), "user_data", e$usr)
+    udat <- file.path("~", ".swirl", "user_data", e$usr)
     if(!file.exists(udat)){
       housekeeping(e)
       dir.create(udat, recursive=TRUE)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -23,7 +23,7 @@ getAssign <- function(var, env1, env2){
 }
 
 cleanAdmin <- function(){
-  udat <- file.path(find.package("swirl"), "user_data", "swirladmin")
+  udat <- file.path("~", ".swirl", "user_data", "swirladmin")
   file.remove(dir(udat, pattern="*[.]rda", full.names=TRUE))
   invisible()
 }


### PR DESCRIPTION
At present, swirl saves all progress and other user info to the installed package directory via `e$udat`. This seems to pose a problem for many users who have read access, but not write access to the package directory. 

The most common result is this (for Coursera submissions):

```
Error in file(con, "w") : cannot open the connection
In addition: Warning message:
In file(con, "w") :
  cannot open file 'rprog-005_Basic_Building_Blocks.txt': Permission denied
```

In the past, I've avoided writing data anywhere outside of the package directory, but the change proposed here seems harmless enough. Note that it creates a **hidden** directory in the user's home directory (`~/.swirl/`).

One other benefit (?) of doing things this way is that user data persists when swirl is re-installed/updated. This could also create clutter if too many unfinished sessions or courses/lessons accumulate over time.

**I'm most concerned about this change working on all platforms, which may not be possible. I'll test on Mac, Windows 7, and Ubuntu as time permits. [This SO thread](http://stackoverflow.com/questions/2552416/how-can-i-find-the-users-home-dir-in-a-cross-platform-manner-using-c) may be relevant.**

@WilCrofter @seankross What are you thoughts?
