### PR TITLE
Allow the use of partner.coursera.org websites for Coursera submission

### DIFF
--- a/R/courseraCheck.R
+++ b/R/courseraCheck.R
@@ -3,6 +3,12 @@ courseraCheck <- function(e){
   modtype <- attr(e$les, "type")
   lesson_name <- gsub(" ", "_", attr(e$les, "lesson_name"))
   if(is.null(modtype) || modtype != "Coursera")return()
+  
+  # allow use of Coursera partner sites (school.coursera.org)
+  partner <- attr(e$les, "partner")
+  partner <- ifelse(is.null(partner), "class", partner)
+  baseurl <- paste0("http://", partner, ".coursera.org/")
+
   tt <- c(rep(letters, 3), seq(100))
   swirl_out("Are you currently enrolled in the Coursera course associated with this lesson?")
   yn <- select.list(c("Yes","No"), graphics=FALSE)
@@ -33,9 +39,9 @@ courseraCheck <- function(e){
     # If doing automatic submission, then give it a try.
     if(choice=="Yes"){
       swirl_out("I'll try to tell Coursera you've completed this lesson now.")
-      challenge.url <- paste("http://class.coursera.org", course_name,
+      challenge.url <- paste(baseurl, course_name,
                              "assignment/challenge", sep = "/")
-      submit.url <- paste("http://class.coursera.org", course_name,
+      submit.url <- paste(baseurl, course_name,
                           "assignment/submit", sep = "/")
       ch <- try(getChallenge(email, challenge.url), silent=TRUE)
       # Check if url is valid, i.e. challenge received

--- a/R/lesson_constructor.R
+++ b/R/lesson_constructor.R
@@ -1,12 +1,12 @@
 # Constructor function for objects of class "lesson"
 lesson <- function(df, lesson_name=NULL, course_name=NULL, author=NULL, 
-                   type=NULL, organization=NULL, version=NULL) {
+                   type=NULL, organization=NULL, version=NULL, partner=NULL) {
   
   if(!is.data.frame(df)) 
     stop("Argument 'df' must be a data frame!")
   
   # Adding secondary class of data.frame allows lessons to retain data.frame attributes (e.g. dim())
   structure(df, lesson_name=lesson_name, course_name=course_name, author=author,
-            type=type, organization=organization, version=version,
+            type=type, organization=organization, version=version, partner=partner,
             class=c("lesson", "data.frame"))
 }

--- a/R/parse_content.R
+++ b/R/parse_content.R
@@ -53,5 +53,5 @@ parse_content.yaml <- function(file, e){
   meta <- raw_yaml[[1]]
   lesson(df, lesson_name=meta$Lesson, course_name=meta$Course,
          author=meta$Author, type=meta$Type, organization=meta$Organization,
-         version=meta$Version)
+         version=meta$Version, partner=meta$Partner)
 }


### PR DESCRIPTION
The submission URL is currently hardcoded as http://class.coursera.edu/...

However, classes set up on Coursera partner internal sites (such as mine) can have addresses such as princeton.coursera.edu, which means one can't submit Coursera assignments to them. With this change one can add an (optional) "Partner" attribute to a lesson's metadata, such that it ends with:

```
Type: Coursera, Version: 1.0, Partner: princeton}
```

and it would know to send the submission to http://princeton.coursera.edu/...

I couldn't think of a way this could be done besides adding an additional metadata field.
