### PR TITLE
correcting bug in omnitest

### DIFF
--- a/R/answerTests2.R
+++ b/R/answerTests2.R
@@ -182,7 +182,7 @@ omnitest <- function(correctExpr=NULL, correctVal=NULL, strict=FALSE, eval_for_c
     NULL
   }
   # Testing for correct expression only
-  if(!is.null(correctExpr) && !is.null(correctVal)){
+  if(!is.null(correctExpr) && is.null(correctVal)){
     err <- try({
       good_expr <- parse(text=correctExpr)[[1]]
       ans <- is_robust_match(good_expr, e$expr, eval_for_class, eval_for_class)


### PR DESCRIPTION
A stray exclamation point prevented an if statement from executing at the proper time. In terms of results, this mattered only when both a correct expression and a correct value were given, in which case it failed to check the value. This usage of omnitest being rare, it was not noticed until testing Statistical Inference.

The affected if statement could have been removed completely with slight loss of efficiency but without loss of function, but instead I've just corrected the typo. The fix has been tested on about half dozen lessons in Statistical Inference. It seems ready to merge.
