### PR TITLE
Force UTF-8 encoding of message in swirl_out to solve WINDOWS-1252 "umlaut" problem.

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -4,6 +4,7 @@ swirl_out <- function(..., skip_before=TRUE, skip_after=FALSE) {
   mes <- str_c("| ", wrapped, collapse = "\n")
   if(skip_before) mes <- paste0("\n", mes)
   if(skip_after) mes <- paste0(mes, "\n")
+  Encoding(mes) <- "UTF-8"
   message(mes)
 }
 


### PR DESCRIPTION
Adds a line, `Encoding(mes) <- "UTF-8"`, to `swirl_out` which forces the string, `mes`, to be interpreted as UTF-8 for printing. This overrides the default which, in Europe on Windows machines, can be the obsolete `WINDOWS-1252` encoding.
