### PR TITLE
Adding print statement in skip() to output the command return value

### DIFF
--- a/R/swirl.R
+++ b/R/swirl.R
@@ -378,6 +378,9 @@ resume.default <- function(e, ...){
       swirl_out("Entering the following correct answer for you...",
                 skip_after=TRUE)
       message("> ", e$current.row[, "CorrectAnswer"])
+      #if(!is.null(e$val)) {
+      #  print(e$val)
+      #}
       
     }
     


### PR DESCRIPTION
Suggestion is to add this print statement to the skip() function so that users skipping question still have the possibility to see the return value associated to the correct command.
