### PR TITLE
Add print statement in skip() to output the command return value

### DIFF
--- a/R/swirl.R
+++ b/R/swirl.R
@@ -378,7 +378,9 @@ resume.default <- function(e, ...){
       swirl_out("Entering the following correct answer for you...",
                 skip_after=TRUE)
       message("> ", e$current.row[, "CorrectAnswer"])
-      
+      if(e$vis && !is.null(e$val)) {
+        print(e$val)
+      }
     }
     
     # Make sure playing flag is off since user skipped

--- a/R/swirl.R
+++ b/R/swirl.R
@@ -370,7 +370,12 @@ resume.default <- function(e, ...){
       }
       e$expr <- parse(text=correctAns)[[1]]
       ce <- cleanEnv(e$snapshot)
-      e$val <- suppressMessages(suppressWarnings(eval(e$expr, ce)))
+      # evaluate e$expr keeping value and visibility information
+      # store the result in temporary object evaluation in order
+      # to avoid double potentially time consuming eval call
+      evaluation <- withVisible(eval(e$expr, ce))
+      e$vis <- evaluation$visible
+      e$val <- suppressMessages(suppressWarnings(evaluation$value))
       xfer(ce, globalenv())
       ce <- as.list(ce)
       
@@ -378,7 +383,8 @@ resume.default <- function(e, ...){
       swirl_out("Entering the following correct answer for you...",
                 skip_after=TRUE)
       message("> ", e$current.row[, "CorrectAnswer"])
-      if(e$vis && !is.null(e$val)) {
+
+      if(e$vis & !is.null(e$val)) {
         print(e$val)
       }
     }


### PR DESCRIPTION
Suggestion is to add this print statement to the skip() function so that users skipping a question still have the possibility to see the return value associated to the correct command.