### PR TITLE
[Readme] remove readme badge.svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/swirldev/swirl.png?branch=master)](https://travis-ci.org/swirldev/swirl)
 [![Downloads](http://cranlogs.r-pkg.org/badges/swirl?color=3399ff)](http://cran-logs.rstudio.com/)
-<a href="https://swirlstatsslack.herokuapp.com"><img src="https://swirlstatsslack.herokuapp.com/badge.svg"></a>
 
 ### [http://swirlstats.com](http://swirlstats.com)
 


### PR DESCRIPTION
This server is currently unreachable, this can be slow down the speed of swirl github page.