### PR TITLE
fix crash on `reset()`

### DIFF
--- a/R/actions.R
+++ b/R/actions.R
@@ -1,5 +1,5 @@
 do_nxt <- function(e)UseMethod("do_nxt")
-do_reset <- function(e)UseMethod("do_rst")
+do_reset <- function(e)UseMethod("do_reset")
 do_submit <- function(e)UseMethod("do_submit")
 do_play <- function(e)UseMethod("do_play")
 do_main <- function(e)UseMethod("do_main")


### PR DESCRIPTION
Previously threw:

``` R
Error in UseMethod("do_rst") :
    no applicable method for 'do_rst' applied to an object of class "c('environment', 'default')"
```

The method is named `do_reset`.

I didn't find a clean way to write a test for the broken code. I
believe a test for this crash would rely on catching an error thrown
from within the task callback handler "mini", inside an active swirl
session. I'll file an issue for this, I think it would be valuable if
we could figure out a clean way to add tests for runtime code.
