### PR TITLE
Make complete_part more robust

### DIFF
--- a/R/menu.R
+++ b/R/menu.R
@@ -175,7 +175,11 @@ mainMenu.default <- function(e){
       # If running in 'test' mode and starting partway through 
       # lesson, then complete first part
       if((is(e, "test") || is(e, "datacamp")) && e$test_from > 1) {
-        complete_part(e)
+        if (e$test_from > nrow(e$les)) {
+          e$test_from <- 1
+        } else {
+          complete_part(e)
+        }
       }
       
       # Remove temp lesson name and course name vars, which were surrogates

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -159,7 +159,7 @@ loadDependencies <- function(lesson_dir) {
 
 # Execute correct answers for rows 1 through 'up_through' of lesson
 complete_part <- function(e) {
-  up_through <- e$test_from - 1
+  up_through <- min(e$test_from - 1, nrow(e$les))
   # Get rows though 'up_through' argument
   les <- e$les[seq(up_through), ]
   # Execute previous correct answers in global env

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -159,7 +159,7 @@ loadDependencies <- function(lesson_dir) {
 
 # Execute correct answers for rows 1 through 'up_through' of lesson
 complete_part <- function(e) {
-  up_through <- min(e$test_from - 1, nrow(e$les))
+  up_through <- e$test_from - 1
   # Get rows though 'up_through' argument
   les <- e$les[seq(up_through), ]
   # Execute previous correct answers in global env


### PR DESCRIPTION
When working with swirl on DataCamp, it happens that the `e$test_from` exceeds the actual number of exercises in the lesson. This gave nasty side effects.

I added an extra check that only does `complete_part()` if `e$test_from` is lower than `nrow(e$les)`. Otherwise, `e$test_from` is simply reset to 1.