### PR TITLE
fix error introduced by strict error handling for logical operators 

### DIFF
--- a/R/answerTests2.R
+++ b/R/answerTests2.R
@@ -205,7 +205,7 @@ omnitest <- function(correctExpr=NULL, correctVal=NULL, strict=FALSE, eval_for_c
       if(is(e, "dev") && !valResults$passed)swirl_out(valResults$message)
       valGood <- valResults$passed
       # valGood <- val_matches(correctVal)
-    } else if(!is.na(e$val) && is.numeric(e$val) && length(e$val) == 1){
+    } else if(length(e$val) == 1 && !is.na(e$val) && is.numeric(e$val) && length(e$val) == 1){
       cval <- try(as.numeric(correctVal), silent=TRUE)
       valResults <- expectThat(e$val, 
                             equals_legacy(cval, label=correctVal),


### PR DESCRIPTION
Starting from R4.3.0, the logical operators && and || throw errors when called with non-scalar values (rather than silently using the first value only).
Some lessons are no longer working due to this behaviour change: https://stackoverflow.com/questions/76273085/r-trouble-in-swirl-when-using
The commit simply checks whether the value is atomic before processing it further.
